### PR TITLE
Changed stream_mode to default gracefully when setting is invalid

### DIFF
--- a/rdioxbmc.py
+++ b/rdioxbmc.py
@@ -111,7 +111,12 @@ class RdioApi:
 
   def resolve_playback_url(self, key):
     playback_url = None
-    stream_mode = int(self._addon.get_setting('stream_mode'))
+    try:
+      stream_mode = int(self._addon.get_setting('stream_mode'))
+    except ValueError:
+      self._addon.log_debug('stream_mode not set, defaulting')
+      stream_mode = None;
+
     if not stream_mode:
       playback_url = self._resolve_rtmp_playback_url_via_flash(key)
     elif stream_mode == 1:


### PR DESCRIPTION
I was seeing playback errors related to this setting being undefined somehow.  I'm assuming this occurred because of upgrading XBMC and the addon settings were lost.  Looking at the code, it appeared that there was an intention to default to flash streaming when the setting was not explicitly set. However, with the setting missing, get_setting was returning and unparsable empty string.

This may not be in the spirit of the original code, but I'm added some error handling for this case that hopefully results in fewer headaches for users that don't care about the stream mode. 
